### PR TITLE
При выстреле у пули отписываюсь от событий

### DIFF
--- a/Assets/Asteroids/Scripts/Controllers/ShootingController.cs
+++ b/Assets/Asteroids/Scripts/Controllers/ShootingController.cs
@@ -31,6 +31,7 @@ public class ShootingController
         if (canShoot && isEnemyDetected)
         {
             _bulletController.Init();
+            _bulletController.OnDisable();
             _bulletController.OnEnable();
             _bulletController.Move();
             

--- a/Assets/Asteroids/Scripts/Others/GameObjectPool.cs
+++ b/Assets/Asteroids/Scripts/Others/GameObjectPool.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 using UnityEngine;
 
 
-public sealed class GameObjectPool 
+public sealed class GameObjectPool
 {
 	private readonly Queue<GameObject> _queue = new Queue<GameObject>();
 	private readonly GameObject _prefab;
@@ -25,8 +25,8 @@ public sealed class GameObjectPool
 		else
 		{
 			_index++;
-            _gameObject = Object.Instantiate(_prefab);
-            _gameObject.name = $"{_prefab.name}({_index})";
+			_gameObject = Object.Instantiate(_prefab);
+			_gameObject.name = $"{_prefab.name}({_index})";
 		}
 
 		_gameObject.SetActive(true);
@@ -36,10 +36,10 @@ public sealed class GameObjectPool
 
 	public void AddToQueue(GameObject gameObject)
 	{
-		if(_queue.Contains(gameObject))
-        {
+		if (_queue.Contains(gameObject))
+		{
 			return;
-        }
+		}
 
 		_queue.Enqueue(gameObject);
 		gameObject.transform.SetParent(_root);


### PR DESCRIPTION
При выстреле один и тот же объект постоянно подписывается на события, но нигде нет отписки - поэтому одинаковые GO пуль попадали в pool столько раз, сколько раз подписались на события.
Возможно стоит отписываться где-то в другом месте, но пока так.